### PR TITLE
Text colour in Steam client might be the same as the background

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -67,7 +67,7 @@
       
       <h5 class="indent">Method A:
         <a href="steam://openurl/https://store.steampowered.com/reservation/ajaxgetuserstate?rgReservationPackageIDs=%5B595603,595604,595605%5D"><button>View in Steam</button></a>
-      and copy rtReserveTime from the response.</h5>
+      and copy rtReserveTime from the response. <i>If you see a black screen, highlight or press CTRL + A to highlight, the text might also be black</i></h5>
       <h5 class="indent">Method B: Log into Steam on your browser. Then visit
         <a href="https://store.steampowered.com/reservation/ajaxgetuserstate?rgReservationPackageIDs=%5B595603,595604,595605%5D" target="_blank">the API for reservations</a>
         . Copy rtReserveTime from the response.</h5>


### PR DESCRIPTION
Added a notice to tell the user to highlight potental hidden/matching colour text to the background.